### PR TITLE
added reproducible example to insert null records for safety echart

### DIFF
--- a/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
+++ b/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
@@ -53,20 +53,24 @@ x <- "data_year"
 y <- "estimate"
 y_min <- 0
 y_max <- 100
-color <- "purples"
+
 geo <- "county_ord"
 fill <- "quintile_ord" 
 facet <- "equity_group_ord"
+
 dec <- 1
 esttype <- "number"
 
+color <- "purples"
 num_colors <- 5
 color_rev <- FALSE
+
 title <- "Traffic Related Deaths and <br> Serious Injuries per 100,000"
 subtitle <- "Census Tract Level"
 source <- paste("Washington Traffic Safety Commission", 
                "U.S. Census Bureau, American Community Survey (ACS) 2020 5-Year Public Use Microdata Sample (PUMS)", sep="\n")
 
+## create chart
 line_chart <- equity_tracker_line_facet(df = df,
                                         geo = geo,
                                         x = x,

--- a/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
+++ b/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
@@ -42,7 +42,7 @@ df_nulls <- d_unnest %>%
 
 ## assemble main table  
 df <- bind_rows(df_base, df_nulls) %>% 
-  arrange(county_ord, equity_group_ord, data_year_num)
+  arrange(county_ord, equity_group_ord, quintile_ord, data_year_num)
  
 
 # prep line chart ----

--- a/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
+++ b/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
@@ -14,9 +14,11 @@ load(file = file.path(base_dir, theme_dir, ind_dir, "rda-data", rda))
 # insert null records ----
 standard_base_year <- 2010
 
+# main table
 df_base <- data_clean %>% 
   mutate(data_year_num = as.numeric(data_year))
 
+# set-up columns to identify missing years by the unique categories/geography
 d <- df_base %>% 
   group_by(county, equity_group, quintile, county_ord, equity_group_ord, quintile_ord) %>% 
   summarise(num_unique_years = length(unique(data_year)),
@@ -24,14 +26,14 @@ d <- df_base %>%
             end_year = as.numeric(max(unique(data_year)))) %>% 
   mutate(base_year = standard_base_year)
 
-# identify missing years by county & quintile
 # create list-column, a vector of missing years in a cell
 d_calc <- d %>% 
   rowwise() %>% 
   mutate(missing_years = ifelse(start_year == base_year, NA, list(seq(base_year, (start_year-1))))) 
 
+# unpack so each missing year is a row of its own
 d_unnest <- d_calc %>% 
-  unnest(missing_years) # unpack so each missing year is a row of its own
+  unnest(missing_years) 
 
 # create table with null records for chart
 df_nulls <- d_unnest %>% 
@@ -47,22 +49,22 @@ df <- bind_rows(df_base, df_nulls) %>%
 
 ## set variables
 
-x = "data_year" 
-y = "estimate"
-y_min = 0
-y_max = 100
-color = "purples"
-geo = "county_ord"
-fill = "quintile_ord" 
-facet = "equity_group_ord"
-dec = 1
-esttype = "number"
+x <- "data_year" 
+y <- "estimate"
+y_min <- 0
+y_max <- 100
+color <- "purples"
+geo <- "county_ord"
+fill <- "quintile_ord" 
+facet <- "equity_group_ord"
+dec <- 1
+esttype <- "number"
 
-num_colors = 5
-color_rev = FALSE
-title = "Traffic Related Deaths and <br> Serious Injuries per 100,000"
-subtitle = "Census Tract Level"
-source = paste("Washington Traffic Safety Commission", 
+num_colors <- 5
+color_rev <- FALSE
+title <- "Traffic Related Deaths and <br> Serious Injuries per 100,000"
+subtitle <- "Census Tract Level"
+source <- paste("Washington Traffic Safety Commission", 
                "U.S. Census Bureau, American Community Survey (ACS) 2020 5-Year Public Use Microdata Sample (PUMS)", sep="\n")
 
 line_chart <- equity_tracker_line_facet(df = df,

--- a/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
+++ b/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
@@ -1,0 +1,84 @@
+library(tidyverse)
+
+source('C:\\Users\\CLam\\github\\equity-tracker\\data-visualization\\equity-tracker-chart-functions.R')
+
+# inputs ----
+
+base_dir <- 'Y:/Equity Indicators/tracker-webpage-content'
+theme_dir <- 'g-transportation'
+ind_dir <- 'g01-safety'
+
+rda <- 'g01-safety-data.rda'
+load(file = file.path(base_dir, theme_dir, ind_dir, "rda-data", rda))
+
+# insert null records ----
+standard_base_year <- 2010
+
+df_base <- data_clean %>% 
+  mutate(data_year_num = as.numeric(data_year))
+
+d <- df_base %>% 
+  group_by(county, equity_group, quintile, county_ord, equity_group_ord, quintile_ord) %>% 
+  summarise(num_unique_years = length(unique(data_year)),
+            start_year = as.numeric(min(unique(data_year))),
+            end_year = as.numeric(max(unique(data_year)))) %>% 
+  mutate(base_year = standard_base_year)
+
+# identify missing years by county & quintile
+# create list-column, a vector of missing years in a cell
+d_calc <- d %>% 
+  rowwise() %>% 
+  mutate(missing_years = ifelse(start_year == base_year, NA, list(seq(base_year, (start_year-1))))) 
+
+d_unnest <- d_calc %>% 
+  unnest(missing_years) # unpack so each missing year is a row of its own
+
+# create table with null records for chart
+df_nulls <- d_unnest %>% 
+  select(county, equity_group, quintile, county_ord, equity_group_ord, quintile_ord, data_year_num = missing_years) %>% 
+  mutate(wt_combo_rate = NA, estimate = NA, data_year = as.character(data_year_num))
+
+# assemble main table  
+df <- bind_rows(df_base, df_nulls) %>% 
+  arrange(county_ord, equity_group_ord, data_year_num)
+ 
+
+# prep line chart ----
+
+## set variables
+
+x = "data_year" 
+y = "estimate"
+y_min = 0
+y_max = 100
+color = "purples"
+geo = "county_ord"
+fill = "quintile_ord" 
+facet = "equity_group_ord"
+dec = 1
+esttype = "number"
+
+num_colors = 5
+color_rev = FALSE
+title = "Traffic Related Deaths and <br> Serious Injuries per 100,000"
+subtitle = "Census Tract Level"
+source = paste("Washington Traffic Safety Commission", 
+               "U.S. Census Bureau, American Community Survey (ACS) 2020 5-Year Public Use Microdata Sample (PUMS)", sep="\n")
+
+line_chart <- equity_tracker_line_facet(df = df,
+                                        geo = geo,
+                                        x = x,
+                                        y = y,
+                                        fill = fill,
+                                        facet = facet,
+                                        y_min = y_min,
+                                        y_max = y_max,
+                                        dec = dec,
+                                        esttype = esttype,
+                                        color = color,
+                                        num_colors = num_colors,
+                                        color_rev = color_rev,
+                                        width = '420px',
+                                        height = '380px')
+
+line_chart

--- a/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
+++ b/data-visualization/tracker-webpage-content/g-transportation/g01-safety/insert-null-records.R
@@ -14,11 +14,11 @@ load(file = file.path(base_dir, theme_dir, ind_dir, "rda-data", rda))
 # insert null records ----
 standard_base_year <- 2010
 
-# main table
+## main table
 df_base <- data_clean %>% 
   mutate(data_year_num = as.numeric(data_year))
 
-# set-up columns to identify missing years by the unique categories/geography
+## set-up columns to identify missing years by the unique categories/geography
 d <- df_base %>% 
   group_by(county, equity_group, quintile, county_ord, equity_group_ord, quintile_ord) %>% 
   summarise(num_unique_years = length(unique(data_year)),
@@ -26,21 +26,21 @@ d <- df_base %>%
             end_year = as.numeric(max(unique(data_year)))) %>% 
   mutate(base_year = standard_base_year)
 
-# create list-column, a vector of missing years in a cell
+## create list-column, a vector of missing years in a cell
 d_calc <- d %>% 
   rowwise() %>% 
   mutate(missing_years = ifelse(start_year == base_year, NA, list(seq(base_year, (start_year-1))))) 
 
-# unpack so each missing year is a row of its own
+## unpack so each missing year is a row of its own
 d_unnest <- d_calc %>% 
   unnest(missing_years) 
 
-# create table with null records for chart
+## create table with null records for chart
 df_nulls <- d_unnest %>% 
   select(county, equity_group, quintile, county_ord, equity_group_ord, quintile_ord, data_year_num = missing_years) %>% 
   mutate(wt_combo_rate = NA, estimate = NA, data_year = as.character(data_year_num))
 
-# assemble main table  
+## assemble main table  
 df <- bind_rows(df_base, df_nulls) %>% 
   arrange(county_ord, equity_group_ord, data_year_num)
  
@@ -48,7 +48,6 @@ df <- bind_rows(df_base, df_nulls) %>%
 # prep line chart ----
 
 ## set variables
-
 x <- "data_year" 
 y <- "estimate"
 y_min <- 0


### PR DESCRIPTION
Added a stand alone reproducible example of null records being added to the main table (`data_clean` object) to produce the final line chart. 

- Run the R script before incorporating the the section that adds null data to make sure chart is good
- Lines 14 to 43 can be copied and pasted into your choice of .Rmd, whatever your preference is for this process to happen.

![image](https://github.com/psrc/equity-tracker/assets/17414750/7b01e33d-3bbb-443c-8e41-f9474db29cfd)
